### PR TITLE
[git-submitpr] Replace draft PR with regular-PR-with-WIP-label

### DIFF
--- a/bin/git-submitpr
+++ b/bin/git-submitpr
@@ -79,12 +79,12 @@ elif git -C "$worktree_dir" push --quiet --set-upstream origin "$branch_name" 2>
   if command -v ghb > /dev/null; then
     # TODO maybe ghb should support -C ?
     pushd "$worktree_dir" >/dev/null
-    ghb pr --no-edit --draft "$remote_branch_name" "$@"
+    ghb pr --no-edit --label "WIP 🚧" "$remote_branch_name" "$@"
     popd >/dev/null
   elif command -v gh > /dev/null; then
     # TODO: does gh not support -C either?
     pushd "$worktree_dir" >/dev/null
-    url=$(gh pr create --draft --fill --base "$remote_branch_name" "$@" | grep github.com)
+    url=$(gh pr create --label "WIP 🚧" --fill --base "$remote_branch_name" "$@" | grep github.com)
     native_open "$url"
     popd >/dev/null
   else


### PR DESCRIPTION
`Free` plans don't support draft PRs for private repos; this changes `git-submitpr` to create a draft PR with a `WIP 🚧` label instead of a draft PR so it works for free private repos.